### PR TITLE
Remove blank issue template

### DIFF
--- a/template/.github/ISSUE_TEMPLATE/blank.md
+++ b/template/.github/ISSUE_TEMPLATE/blank.md
@@ -1,8 +1,0 @@
----
-name: Blank
-about: General issue that does not fit another category
-title: ''
-labels: ''
-assignees: ''
-
----


### PR DESCRIPTION
This is no longer needed because GH always provides a blank template automatically now.