### PR TITLE
Create dependabot.yml and add scipp dependabot check.

### DIFF
--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Note: We are not listing package-ecosystem: "github-actions". This causes
+  # noise in all template instances. Instead dependabot.yml in scipp/copier_template
+  # triggers updates of github-actions in the *template*. We then use `copier update`
+  # in template instances.
+  - package-ecosystem: "pip"
+    directory: "/requirements"
+    schedule:
+      interval: "quarterly"
+    allow:
+      - dependency-name: "scipp"
+        dependency-type: "direct"


### PR DESCRIPTION
Coming from the other [copier template](https://github.com/scipp/copier_template).

We would like to move scipp specific parts to `ess_template`. https://github.com/scipp/copier_template/issues/196
We have lower-bound and latest-release and nightly-build tests so we don't have to update `scipp` version in our lock files so often.
But it's also good to keep it up to date once in a while so I didn't completely remove it. And it also reminds us to lock the new dependencies.